### PR TITLE
Make head and tail corrections more robust

### DIFF
--- a/msibi/forces.py
+++ b/msibi/forces.py
@@ -776,7 +776,7 @@ class Bond(Force):
         smoothing_window: Optional[int] = None,
         smoothing_order: Optional[int] = None,
         correction_fit_window: Optional[int] = None,
-        maxfev: Optional[int] = 1e3,
+        maxfev: Optional[int] = 1000,
         correction_form: Callable = harmonic,
     ):
         self.type1, self.type2 = sorted([type1, type2], key=natural_sort)
@@ -920,7 +920,7 @@ class Angle(Force):
         smoothing_window: Optional[int] = None,
         smoothing_order: Optional[int] = None,
         correction_fit_window: Optional[int] = None,
-        maxfev: Optional[int] = 1e3,
+        maxfev: Optional[int] = 1000,
         correction_form: Callable = harmonic,
     ):
         self.type1 = type1
@@ -1073,7 +1073,7 @@ class Pair(Force):
         smoothing_window: Optional[int] = None,
         smoothing_order: Optional[int] = None,
         correction_fit_window: Optional[int] = None,
-        maxfev: Optional[int] = 1e3,
+        maxfev: Optional[int] = 1000,
         exclude_bonded: bool = False,
         head_correction_form: Callable = exponential,
     ):
@@ -1228,7 +1228,7 @@ class Dihedral(Force):
         smoothing_window: Optional[int] = None,
         smoothing_order: Optional[int] = None,
         correction_fit_window: Optional[int] = None,
-        maxfev: Optional[int] = 1e3,
+        maxfev: Optional[int] = 1000,
         correction_form: Callable = harmonic,
     ):
         self.type1 = type1

--- a/msibi/forces.py
+++ b/msibi/forces.py
@@ -73,8 +73,10 @@ class Force:
         The window size (number of data points) to use when fitting
         the iterative potential to head and tail correction forms.
         This is only used when the Force is set to be optimized.
-    max_ev : int, optional
-
+    maxfev : int, optional
+        Sets the maximum number of attemps when using scipy.curve_fit
+        to apply head and tail corrections. Use larger values to improve
+        likelihood of successful corrections, but this may slow performance.
     correction_form: Callable, optional
         The type of correciton form to apply to the potential.
         This is only used when the Force is set to be optimized.
@@ -92,6 +94,7 @@ class Force:
         smoothing_window: Optional[int] = None,
         smoothing_order: Optional[int] = None,
         correction_fit_window: Optional[int] = None,
+        maxfev: Optional[int] = 1000,
         correction_form: Optional[Callable] = None,
     ):
         if optimize and not nbins or optimize and nbins <= 0:
@@ -103,6 +106,7 @@ class Force:
         self.optimize = optimize
         self._nbins = nbins
         self.correction_fit_window = correction_fit_window if optimize else None
+        self.maxfev = int(maxfev)
         self.correction_form = correction_form
         self._smoothing_window = smoothing_window if optimize else None
         self._smoothing_order = smoothing_order if optimize else None
@@ -699,6 +703,7 @@ class Force:
                 smoothing_window=self.smoothing_window,
                 smoothing_order=self.smoothing_order,
                 fit_window_size=self.correction_fit_window,
+                maxfev=self.maxfev,
                 head_correction_func=self.correction_form,
             )
         else:  # Bonded force, use correction form on both head and tail of potential
@@ -708,6 +713,7 @@ class Force:
                 smoothing_window=self.smoothing_window,
                 smoothing_order=self.smoothing_order,
                 fit_window_size=self.correction_fit_window,
+                maxfev=self.maxfev,
                 head_correction_func=self.correction_form,
                 tail_correction_func=self.correction_form,
             )
@@ -751,6 +757,10 @@ class Bond(Force):
         The window size (number of data points) to use when fitting
         the iterative potential to head and tail correction forms.
         This is only used when the Force is set to be optimized.
+    maxfev : int, optional
+        Sets the maximum number of attemps when using scipy.curve_fit
+        to apply head and tail corrections. Use larger values to improve
+        likelihood of successful corrections, but this may slow performance.
     correction_form: Callable, default=msibi.utils.corrections.harmonic
         The type of correciton form to apply to the potential.
         This is only used when the Force is set to be optimized.
@@ -766,6 +776,7 @@ class Bond(Force):
         smoothing_window: Optional[int] = None,
         smoothing_order: Optional[int] = None,
         correction_fit_window: Optional[int] = None,
+        maxfev: Optional[int] = 1e3,
         correction_form: Callable = harmonic,
     ):
         self.type1, self.type2 = sorted([type1, type2], key=natural_sort)
@@ -777,6 +788,7 @@ class Bond(Force):
             smoothing_window=smoothing_window,
             smoothing_order=smoothing_order,
             correction_fit_window=correction_fit_window,
+            maxfev=maxfev,
             correction_form=correction_form,
         )
         if self.optimize:
@@ -888,6 +900,10 @@ class Angle(Force):
         The window size (number of data points) to use when fitting
         the iterative potential to head and tail correction forms.
         This is only used when the Force is set to be optimized.
+    maxfev : int, optional
+        Sets the maximum number of attemps when using scipy.curve_fit
+        to apply head and tail corrections. Use larger values to improve
+        likelihood of successful corrections, but this may slow performance.
     correction_form: Callable, default=msibi.utils.corrections.harmonic
         The type of correciton form to apply to the potential.
         This is only used when the Force is set to be optimized.
@@ -904,6 +920,7 @@ class Angle(Force):
         smoothing_window: Optional[int] = None,
         smoothing_order: Optional[int] = None,
         correction_fit_window: Optional[int] = None,
+        maxfev: Optional[int] = 1e3,
         correction_form: Callable = harmonic,
     ):
         self.type1 = type1
@@ -917,6 +934,7 @@ class Angle(Force):
             smoothing_window=smoothing_window,
             smoothing_order=smoothing_order,
             correction_fit_window=correction_fit_window,
+            maxfev=maxfev,
             correction_form=correction_form,
         )
         if self.optimize:
@@ -1034,6 +1052,10 @@ class Pair(Force):
         The window size (number of data points) to use when fitting
         the iterative potential to head and tail correction forms.
         This is only used when the Force is set to be optimized.
+    maxfev : int, optional
+        Sets the maximum number of attemps when using scipy.curve_fit
+        to apply head and tail corrections. Use larger values to improve
+        likelihood of successful corrections, but this may slow performance.
     correction_form: Callable, default=msibi.utils.corrections.harmonic
         The type of correciton form to apply to the potential.
         This is only used when the Force is set to be optimized.
@@ -1051,6 +1073,7 @@ class Pair(Force):
         smoothing_window: Optional[int] = None,
         smoothing_order: Optional[int] = None,
         correction_fit_window: Optional[int] = None,
+        maxfev: Optional[int] = 1e3,
         exclude_bonded: bool = False,
         head_correction_form: Callable = exponential,
     ):
@@ -1068,6 +1091,7 @@ class Pair(Force):
             smoothing_window=smoothing_window,
             smoothing_order=smoothing_order,
             correction_fit_window=correction_fit_window,
+            maxfev=maxfev,
             correction_form=head_correction_form,
         )
         if self.optimize:
@@ -1183,6 +1207,10 @@ class Dihedral(Force):
         The window size (number of data points) to use when fitting
         the iterative potential to head and tail correction forms.
         This is only used when the Force is set to be optimized.
+    maxfev : int, optional
+        Sets the maximum number of attemps when using scipy.curve_fit
+        to apply head and tail corrections. Use larger values to improve
+        likelihood of successful corrections, but this may slow performance.
     correction_form: Callable, default=msibi.utils.corrections.harmonic
         The type of correciton form to apply to the potential.
         This is only used when the Force is set to be optimized.
@@ -1200,6 +1228,7 @@ class Dihedral(Force):
         smoothing_window: Optional[int] = None,
         smoothing_order: Optional[int] = None,
         correction_fit_window: Optional[int] = None,
+        maxfev: Optional[int] = 1e3,
         correction_form: Callable = harmonic,
     ):
         self.type1 = type1
@@ -1214,6 +1243,7 @@ class Dihedral(Force):
             smoothing_window=smoothing_window,
             smoothing_order=smoothing_order,
             correction_fit_window=correction_fit_window,
+            maxfev=maxfev,
             correction_form=correction_form,
         )
         if self.optimize:

--- a/msibi/forces.py
+++ b/msibi/forces.py
@@ -73,6 +73,8 @@ class Force:
         The window size (number of data points) to use when fitting
         the iterative potential to head and tail correction forms.
         This is only used when the Force is set to be optimized.
+    max_ev : int, optional
+
     correction_form: Callable, optional
         The type of correciton form to apply to the potential.
         This is only used when the Force is set to be optimized.

--- a/msibi/tests/test_corrections.py
+++ b/msibi/tests/test_corrections.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from msibi.utils.corrections import (
     bonded_corrections,
@@ -52,6 +53,24 @@ def test_harmonic_bonded_correction():
     assert np.array_equal(real_indices, np.arange(15, 85))
     assert head_start == 15
     assert tail_start == 85
+
+
+def test_undefined_error():
+    """Catch error when large region of undefined values exist within defined potential range."""
+    x, V = generate_parabolic_potential(x0=2, x_range=(0, 4), noise_level=0)
+    V_missing = np.copy(V)
+    V_missing[15:25] = np.inf
+    with pytest.raises(RuntimeError):
+        V_corrected, head_start, tail_start, real_indices = bonded_corrections(
+            x=x,
+            V=V_missing,
+            fit_window_size=15,
+            head_correction_func=harmonic,
+            tail_correction_func=harmonic,
+            maxfev=1000,
+            smoothing_order=None,
+            smoothing_window=None,
+        )
 
 
 def test_linear_bonded_correction():

--- a/msibi/tests/test_corrections.py
+++ b/msibi/tests/test_corrections.py
@@ -61,7 +61,7 @@ def test_undefined_error():
     V_missing = np.copy(V)
     V_missing[15:25] = np.inf
     with pytest.raises(RuntimeError):
-        V_corrected, head_start, tail_start, real_indices = bonded_corrections(
+        bonded_corrections(
             x=x,
             V=V_missing,
             fit_window_size=15,

--- a/msibi/tests/test_corrections.py
+++ b/msibi/tests/test_corrections.py
@@ -44,6 +44,7 @@ def test_harmonic_bonded_correction():
         fit_window_size=15,
         head_correction_func=harmonic,
         tail_correction_func=harmonic,
+        maxfev=1000,
         smoothing_order=None,
         smoothing_window=None,
     )
@@ -63,6 +64,7 @@ def test_linear_bonded_correction():
         x=x,
         V=V_missing,
         fit_window_size=15,
+        maxfev=1000,
         head_correction_func=linear,
         tail_correction_func=linear,
         smoothing_order=None,
@@ -90,6 +92,7 @@ def test_exponential_bonded_correction():
         x=x,
         V=V_missing,
         fit_window_size=15,
+        maxfev=1000,
         head_correction_func=exponential,
         tail_correction_func=exponential,
         smoothing_order=None,
@@ -114,6 +117,7 @@ def test_pair_tail_corrections():
         V=V,
         fit_window_size=10,
         r_switch=2,
+        maxfev=1000,
         smoothing_window=None,
         smoothing_order=None,
         head_correction_func=exponential,
@@ -132,6 +136,7 @@ def test_pair_no_tail_corrections():
         r_switch=None,
         smoothing_window=None,
         smoothing_order=None,
+        maxfev=1000,
         head_correction_func=exponential,
     )
     assert np.array_equal(V, V_corrected)

--- a/msibi/utils/corrections.py
+++ b/msibi/utils/corrections.py
@@ -216,10 +216,11 @@ def _get_real_indices(V: np.ndarray):
     # Check for continuity of real_indices:
     if not np.all(np.ediff1d(real_idx) == 1):
         min_window = np.max(np.ediff1d(real_idx)) - 1
-        print("MIN WINDOW", min_window)
         if min_window > 5:
-            # TODO: raise warning or error
-            raise RuntimeError("Too large of a region of undefined values.")
+            raise RuntimeError(
+                "The region of undefined values within the potential is too large. "
+                "This could be the result of a sampling issue. Check the target distributions."
+            )
         start = real_idx[0]
         end = real_idx[-1]
         # Correct nans, infs that are surrounded by 2 finite numbers

--- a/msibi/utils/corrections.py
+++ b/msibi/utils/corrections.py
@@ -47,6 +47,7 @@ def bonded_corrections(
     smoothing_window: int,
     smoothing_order: int,
     fit_window_size: int,
+    maxfev: int,
     head_correction_func: Callable,
     tail_correction_func: Callable,
 ):
@@ -104,7 +105,7 @@ def bonded_corrections(
         f=head_correction_func,
         xdata=x_head_fit,
         ydata=v_real[:fit_window_size],
-        maxfev=10000,
+        maxfev=maxfev,
     )
     x_head_missing = _shift_x(x[:head_start], origin=x_head_pivot)
     # Apply these parameters to the x-range where we are missing data
@@ -115,7 +116,7 @@ def bonded_corrections(
         f=tail_correction_func,
         xdata=x_real[-fit_window_size:],
         ydata=v_real[-fit_window_size:],
-        maxfev=10000,
+        maxfev=maxfev,
     )
     tail_pot_correction = tail_correction_func(x[tail_start + 1 :], *popt_tail)
 
@@ -133,6 +134,7 @@ def pair_corrections(
     smoothing_window: int,
     smoothing_order: int,
     fit_window_size: int,
+    maxfev: int,
     head_correction_func: Callable,
 ):
     """The default correction method for bonded forces.
@@ -180,6 +182,7 @@ def pair_corrections(
         f=head_correction_func,
         xdata=x_real[: fit_window_size + 1],
         ydata=v_real[: fit_window_size + 1],
+        maxfev=maxfev,
     )
     head_pot_correction = head_correction_func(x[:head_start], *popt_head)
 

--- a/msibi/utils/corrections.py
+++ b/msibi/utils/corrections.py
@@ -85,11 +85,16 @@ def bonded_corrections(
     # The smoothed real portion of the potential isn't retained here
     # That is handled seaprately and performed on the potential with head & tail corrections included
     if all([smoothing_window, smoothing_order]):
+        if len(v_real) < 2 * smoothing_window:
+            mode = "nearest"
+        else:
+            mode = "interp"
+
         v_real = savgol_filter(
             x=v_real,
             window_length=smoothing_window,
             polyorder=smoothing_order,
-            mode="mirror",
+            mode=mode,
         )
 
     # head correction (i.e., left side of potential)

--- a/msibi/utils/corrections.py
+++ b/msibi/utils/corrections.py
@@ -85,15 +85,11 @@ def bonded_corrections(
     # The smoothed real portion of the potential isn't retained here
     # That is handled seaprately and performed on the potential with head & tail corrections included
     if all([smoothing_window, smoothing_order]):
-        if len(v_real) < 2 * smoothing_window:
-            mode = "nearest"
-        else:
-            mode = "interp"
         v_real = savgol_filter(
             x=v_real,
             window_length=smoothing_window,
             polyorder=smoothing_order,
-            mode=mode,
+            mode="mirror",
         )
 
     # head correction (i.e., left side of potential)
@@ -237,27 +233,6 @@ def _get_real_indices(V: np.ndarray):
         _real_idx = np.where(np.isfinite(V))[0]
         real_idx = max([list(g) for g in mit.consecutive_groups(_real_idx)], key=len)
     return real_idx
-
-
-# def _get_real_indices(V: np.ndarray):
-#    """Find where infinity or NaN values exist in the potential."""
-#    real_idx = np.where(np.isfinite(V))[0]
-#    # Check for continuity of real_indices:
-#    if not np.all(np.ediff1d(real_idx) == 1):
-#        start = real_idx[0]
-#        end = real_idx[-1]
-#        # Correct nans, infs that are surrounded by 2 finite numbers
-#        for idx, v in enumerate(V[start:end]):
-#            if not np.isfinite(v):
-#                try:
-#                    avg = (V[idx + start - 1] + V[idx + start + 1]) / 2
-#                    V[idx + start] = avg
-#                except IndexError:
-#                    pass
-#        # Trim off edge cases
-#        _real_idx = np.where(np.isfinite(V))[0]
-#        real_idx = max([list(g) for g in mit.consecutive_groups(_real_idx)], key=len)
-#    return real_idx
 
 
 def _shift_x(x: np.ndarray, origin: Union[float, int]):


### PR DESCRIPTION
This PR adds a few changes to `corrections.py`. 

Before, if the potential contained infs or nans in between real values, we would try to take the average of the left and right neighbors. This didn't work in a case where the left or right neighbor was also an inf/nan. Now, it tries to find the minimum window it needs to use to do the averaging and throws the error if the windows are too large, which indicates a sampling issue.

This also makes it so the `maxfev` arugment for scipy's curve-fit can be set, which is useful for potentials which are proving to be more troublesome to fit the corrections to.